### PR TITLE
wildfly-maven-plugin for "mvn wildfly:deploy"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,10 @@
 					</execution>
 				</executions>
 			</plugin>
+			<plugin><!-- to deploy run: mvn wildfly:deploy -->
+				<groupId>org.wildfly.plugins</groupId>
+				<artifactId>wildfly-maven-plugin</artifactId>
+			</plugin>
 		</plugins>
 	</build>
 


### PR DESCRIPTION
Added wildfly-maven-plugin to be able to deploy to running wildfly using
```
mvn wildfly:deploy
```